### PR TITLE
Remove unnecessary async from account queries

### DIFF
--- a/Accounts/Types/Query.cs
+++ b/Accounts/Types/Query.cs
@@ -7,13 +7,13 @@ public static class Query
 {
     public static IQueryable<User> GetUsers()
         => Repo.Users.OrderByDescending(t => t.Id).AsQueryable();
-    
-    public static async Task<User?> GetUserById(int id)
+
+    public static User? GetUserById(int id)
         => Repo.Users.FirstOrDefault(u => u.Id == id);
-    
-    public static async Task<IQueryable<User>?> GetUsersById(int[] ids)
+
+    public static IQueryable<User> GetUsersById(int[] ids)
         => Repo.Users.Where(u => ids.Contains(u.Id)).AsQueryable();
-    
-    public static async Task<User> GetUsersByUsername(string username)
+
+    public static User? GetUserByUsername(string username)
         => Repo.Users.FirstOrDefault(u => u.Username == username);
 }


### PR DESCRIPTION
## Summary
- make account query resolvers synchronous
- fix user lookup by username to return nullable result

## Testing
- `~/.dotnet/dotnet build GatewayGraphQL.sln`

------
https://chatgpt.com/codex/tasks/task_e_6893a952cce48323b83cc92444c28050